### PR TITLE
Use uglifycss as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "modern-css-reset",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "uglifycss": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/uglifycss/-/uglifycss-0.0.29.tgz",
-      "integrity": "sha512-J2SQ2QLjiknNGbNdScaNZsXgmMGI0kYNrXaDlr4obnPW9ni1jljb1NeEVWAiTgZ8z+EBWP2ozfT9vpy03rjlMQ=="
+      "integrity": "sha512-J2SQ2QLjiknNGbNdScaNZsXgmMGI0kYNrXaDlr4obnPW9ni1jljb1NeEVWAiTgZ8z+EBWP2ozfT9vpy03rjlMQ==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/hankchizljaw/modern-css-reset/issues"
   },
   "homepage": "https://github.com/hankchizljaw/modern-css-reset#readme",
-  "dependencies": {
+  "devDependencies": {
     "uglifycss": "0.0.29"
   }
 }


### PR DESCRIPTION
Since the uglify dependency is used as a development tool in this project, it can be moved to the dev dependencies and not be installed in consuming projects if not needed.