### PR TITLE
Make animations end instantly instead of not run

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -70,7 +70,7 @@ select {
 /* Remove _all_ animations and transitions for people that prefer not to see them */
 @media (prefers-reduced-motion: reduce) {
   * {
-    animation-play-state: paused !important;
+    animation-duration: 0s !important;
     transition: none !important;
     scroll-behavior: auto !important;
   }


### PR DESCRIPTION
If anything depends on the animation to be visible, it will still be visible. Could probably keep `paused` in there as well

Demo comparison: https://codepen.io/psimyn/pen/KKPOgOQ

Thanks for the excellent reset & write-up!