### PR TITLE
Fix styles breaking transitionend/animationend event

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -67,11 +67,11 @@ select {
   font: inherit;
 }
 
-/* Remove _all_ animations and transitions for people that prefer not to see them */
+/* Remove transitions for people that prefer not to see them */
+/* Animations should be handled manually */
 @media (prefers-reduced-motion: reduce) {
   * {
-    animation-play-state: paused !important;
-    transition: none !important;
+    transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/src/reset.css
+++ b/src/reset.css
@@ -67,10 +67,11 @@ select {
   font: inherit;
 }
 
-/* Remove transitions for people that prefer not to see them */
-/* Animations should be handled manually */
+/* Remove all animations and transitions for people that prefer not to see them */
 @media (prefers-reduced-motion: reduce) {
   * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }


### PR DESCRIPTION
https://codepen.io/atomiks/pen/gOOYGgM

I don't think it's possible to force `animation`s paused, due to the `animationend` event, and using `animation-duration: 0.01ms` instead (or shorter) creates a weird initial jerk in Firefox, and Chrome/Safari flicker if it's an infinite animation unless the duration is like `0.000001ms`. Forcing anything there seems unsafe.

Fixes #5 