### PR TITLE
Only vertical resizing of <textarea>

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -76,3 +76,8 @@ select {
     scroll-behavior: auto !important;
   }
 }
+
+/* Only vertical resizing of <textarea> */
+textarea {
+  resize: vertical;
+}


### PR DESCRIPTION
Most layouts are vertical and it's handy to disable horizontal resizing