### PR TITLE
Make <fieldset> work good with {display:flex}

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -76,3 +76,8 @@ select {
     scroll-behavior: auto !important;
   }
 }
+
+/* Make <fieldset> work good with {display:flex} */
+fieldset {
+  min-width: 0;
+}


### PR DESCRIPTION
Sometimes `<fieldset>` works buggy with `display: flex`. Adding `min-width: 0` removes this issue.