### PR TITLE
set img styles also for picture tag

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -51,7 +51,8 @@ a:not([class]) {
 }
 
 /* Make images easier to work with */
-img {
+img,
+picture {
   max-width: 100%;
   display: block;
 }


### PR DESCRIPTION
Happy birthday Andy!

When using your great reset styles, I realised that my `<picture>` elements are not picking up the margin of your (also very cool) `.flow` class. This is indeed because `<picture>` is not set to `block` in contrary to the `<img>` element. My pull request improves consistency by setting the the same styles for the picture as for the img.