### PR TITLE
Reduce motion of ::before and ::after pseudo-elements

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -77,7 +77,9 @@ img:not([alt]) {
 
 /* Remove all animations and transitions for people that prefer not to see them */
 @media (prefers-reduced-motion: reduce) {
-  * {
+  *,
+  *::before,
+  *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;


### PR DESCRIPTION
The change adds the `*::before` and `*::after` in the reduce motion media query. Effectively these additions should prevent any animations which were happening in these pseudo-elements when the user has opted to reduce the motion. 

Why?
I've come across an edge case where I'm animating an `::after` (not sure if that's the ideal way to do it), but animations should be disabled for these pseudo-elements as well.