### PR TITLE
content property block

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -5,6 +5,12 @@
   box-sizing: border-box;
 }
 
+/* Enable pseudo-content styling */
+*::before,
+*::after {
+  content: '';
+}
+
 /* Remove default margin */
 body,
 h1,


### PR DESCRIPTION
Because you can't style pseudo-content without declaring `content` innit.