### PR TITLE
Reset box-sizing on html and inherit everywhere else

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -1,8 +1,9 @@
 /* Box sizing rules */
-*,
-*::before,
-*::after {
+html {
   box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
 }
 
 /* Remove default margin */


### PR DESCRIPTION
As stated in this article https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ , quoting @jonathantneal:

> This will give you the same result, and make it easier to change the box-sizing in plugins or other components that leverage other behavior.

This is just a suggestion, feel free to refuse it! 😁