### PR TITLE
Reset height of img to preserve aspect-ratio

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -46,6 +46,7 @@ a:not([class]) {
 img,
 picture {
   max-width: 100%;
+  height: auto;
   display: block;
 }
 


### PR DESCRIPTION
This [example](https://codepen.io/thierry/pen/jOBMjKv) shows the importance of resetting the height of images styled with min/max-width